### PR TITLE
5.0.2 - Not need two no-unused-vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,12 +94,6 @@ module.exports = {
         "error",
         4
       ],
-      "no-unused-vars": [
-        "error",
-        {
-          "ignoreRestSiblings": true
-        }
-      ],
       "no-console": [
         "error",
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 
     "name": "eslint-config-keepfy",
-    "version": "5.0.1",
+    "version": "5.0.2",
     "description": "Default coding style for keepfy react+ts projects",
     "repository": "https://github.com/keepfy/eslint-config-keepfy.git",
     "main": "index.js",


### PR DESCRIPTION
We already have this with `@typescript-eslint/no-unused-vars`