### PR TITLE
Update eslint and other packages, fix switch cases and delimiter styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ module.exports = {
       "plugin:@typescript-eslint/recommended",
       "plugin:react/recommended",
       "eslint:recommended",
-      "prettier",
-      "prettier/@typescript-eslint",
       "plugin:ramda/recommended"
     ],
     "rules": {
@@ -90,9 +88,13 @@ module.exports = {
       "curly": "error",
       "no-undef": "off",
       "no-case-declarations": "off",
+      "@typescript-eslint/indent": "off",
       "indent": [
         "error",
-        4
+        4,
+        {
+          "SwitchCase": 1
+        }
       ],
       "no-console": [
         "error",
@@ -186,6 +188,16 @@ module.exports = {
           "ignoreRestSiblings": true
         }
       ],
+      "@typescript-eslint/member-delimiter-style": [
+          "error",{
+          "multiline": {
+            "delimiter": "none"
+          },
+          "singleline": {
+            "delimiter": "comma",
+            "requireLast": false
+          }
+        }],
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/class-name-casing": "error",
       "@typescript-eslint/member-ordering": [

--- a/package.json
+++ b/package.json
@@ -1,21 +1,19 @@
 {
-
     "name": "eslint-config-keepfy",
-    "version": "5.0.2",
+    "version": "6.0.0",
     "description": "Default coding style for keepfy react+ts projects",
     "repository": "https://github.com/keepfy/eslint-config-keepfy.git",
     "main": "index.js",
     "dependencies": {
-        "@typescript-eslint/eslint-plugin": "1.5.0",
-        "@typescript-eslint/parser": "1.5.0",
-        "eslint-config-prettier": "4.1.0",
-        "eslint-plugin-import": "2.16.0",
-        "eslint-plugin-prefer-arrow": "1.1.5",
+        "@typescript-eslint/eslint-plugin": "2.4.0",
+        "@typescript-eslint/parser": "2.4.0",
+        "eslint-plugin-import": "2.18.2",
+        "eslint-plugin-prefer-arrow": "1.1.6",
         "eslint-plugin-ramda": "2.5.1",
-        "eslint-plugin-react": "7.12.4"
+        "eslint-plugin-react": "7.16.0"
     },
     "peerDependencies": {
-        "eslint": "^5.15.3",
+        "eslint": "^6.5.1",
         "ramda": "^0.26.1"
     }
 }


### PR DESCRIPTION
This PR fixes some issues with our code styles:
* Fix the code style for switches:

Before:
```typescript
switch(cond) {
case 'one':
    return 1
default: 
    return NaN
}
```
After:
```typescript
switch(cond) {
    case 'one': 
        return 1
    default:
        return NaN
}
```
* Enforce `member-delimiter-style` on ts types to be `none`, and enforce `comma` when single line
* I've removed the prettier dependencies, we're not using it anymore cuz it's annoying.
* Disabled the `@typescript-eslint/indent`, the default `indent` rule from eslint package already works with ts files

This is a breaking change.
